### PR TITLE
[demo] Remove extra unused heap

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,6 @@ The NEORV32-specific parts are configured right inside the `main.c` file and the
 The hardware abstraction layer (HAL) is provided by the NEORV32 software framework, which also provides
 the start-up code and linker script.
 
-As the linker script is also responsible for configuring application- and setup-specific memory layout
-the actual configuration has to be overridden according to the application setup. For example the heap
-size is configured by `configTOTAL_HEAP_SIZE` in `FreeRTOSConfig.h`. This size also needs to be
-configured for the linker script, which is done inside the `makefile`:
-
-```makefile
-override USER_FLAGS += "-Wl,--defsym,__neorv32_heap_size=3500"
-```
-
 > [!TIP]
 > More information regarding the NEORV32 software framework can be found in the
 [online data sheet](https://stnolting.github.io/neorv32/#_software_framework).

--- a/demo/blinky.c
+++ b/demo/blinky.c
@@ -134,7 +134,7 @@ void blinky( void ) {
      * there was insufficient FreeRTOS heap memory available for the Idle and/or
      * timer tasks to be created.  See the memory management section on the
      * FreeRTOS web site for more details on the FreeRTOS heap
-     * https://www.FreeRTOS.org/a00111.html. */
+     * https://www.FreeRTOS.org/a00111.html */
     for( ;; );
 }
 /*-----------------------------------------------------------*/

--- a/demo/main.c
+++ b/demo/main.c
@@ -117,15 +117,6 @@ static void prvSetupHardware(void) {
     neorv32_uart_printf(UART_HW_HANDLE, "WARNING! GPTMR timer not available!\n");
   }
 
-  // check heap size configuration
-  if ((uint32_t)neorv32_heap_size_c != (uint32_t)configTOTAL_HEAP_SIZE){
-    neorv32_uart_printf(UART_HW_HANDLE,
-                        "WARNING! Incorrect 'configTOTAL_HEAP_SIZE' configuration!\n"
-                        "FreeRTOS configTOTAL_HEAP_SIZE: %u bytes\n"
-                        "NEORV32 makefile heap size:     %u bytes\n\n",
-                        (uint32_t)configTOTAL_HEAP_SIZE, neorv32_heap_size_c);
-  }
-
   // check clock frequency configuration
   uint32_t neorv32_clk_hz = (uint32_t)NEORV32_SYSINFO->CLK;
   if (neorv32_clk_hz != (uint32_t)configCPU_CLOCK_HZ) {
@@ -245,11 +236,15 @@ void vApplicationMallocFailedHook(void) {
 	function that will get called if a call to pvPortMalloc() fails.
 	pvPortMalloc() is called internally by the kernel whenever a task, queue,
 	timer or semaphore is created. It is also called by various parts of the
-	demo application. If heap_1.c or heap_2.c are used, then the size of the
-	heap available to pvPortMalloc() is defined by configTOTAL_HEAP_SIZE in
-	FreeRTOSConfig.h, and the xPortGetFreeHeapSize() API function can be used
-	to query the size of free heap space that remains (although it does not
-	provide information on how the remaining heap might be fragmented). */
+	demo application. The size of the heap available to pvPortMalloc() is
+	defined by configTOTAL_HEAP_SIZE in FreeRTOSConfig.h. The
+	xPortGetFreeHeapSize() API function can be used to query the size of free
+	heap space that remains (although it does not provide information on how
+	the remaining heap might be fragmented).
+
+	If heap_3.c is used, then configTOTAL_HEAP_SIZE has no effect and the heap
+	size is instead defined by setting the linker variable __neorv32_heap_size.
+	xPortGetFreeHeapSize() cannot be used with heap_3.c. */
 
 	taskDISABLE_INTERRUPTS();
 

--- a/demo/makefile
+++ b/demo/makefile
@@ -43,9 +43,6 @@ APP_SRC += $(wildcard  $(FREERTOS_HOME)/portable/MemMang/heap_4.c)
 # NEORV32 home folder
 NEORV32_HOME ?= ../neorv32
 
-# Set maximum heap size
-override USER_FLAGS += "-Wl,--defsym,__neorv32_heap_size=3500"
-
 # Chip-specific configuration
 APP_INC += -I chip_specific_extensions/neorv32
 ASM_INC += -I chip_specific_extensions/neorv32


### PR DESCRIPTION
When using `heap_[1|2|4|5].c`, FreeRTOS allocates its own memory for the heap, and doesn't use C's heap. The demo application uses `heap_4.c` and sets both `configTOTAL_HEAP_SIZE` and ` __neorv32_heap_size` to 3500. This results in the demo using an extra 3500 bytes.